### PR TITLE
feat: Implement campaign analytics API

### DIFF
--- a/xtremand-analytics/pom.xml
+++ b/xtremand-analytics/pom.xml
@@ -16,5 +16,15 @@
                         <groupId>com.xtremand</groupId>
                         <artifactId>xtremand-config</artifactId>
                 </dependency>
+                <dependency>
+                        <groupId>com.xtremand</groupId>
+                        <artifactId>xtremand-domain</artifactId>
+                        <version>0.0.1-SNAPSHOT</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.xtremand</groupId>
+                    <artifactId>xtremand-email</artifactId>
+                    <version>0.0.1-SNAPSHOT</version>
+                </dependency>
         </dependencies>
 </project>

--- a/xtremand-analytics/src/main/java/com/xtremand/analytics/controller/CampaignAnalyticsController.java
+++ b/xtremand-analytics/src/main/java/com/xtremand/analytics/controller/CampaignAnalyticsController.java
@@ -1,0 +1,24 @@
+package com.xtremand.analytics.controller;
+
+import com.xtremand.analytics.service.CampaignAnalyticsService;
+import com.xtremand.domain.dto.CampaignAnalyticsDto;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/analytics/campaigns")
+public class CampaignAnalyticsController {
+
+    private final CampaignAnalyticsService campaignAnalyticsService;
+
+    public CampaignAnalyticsController(CampaignAnalyticsService campaignAnalyticsService) {
+        this.campaignAnalyticsService = campaignAnalyticsService;
+    }
+
+    @GetMapping
+    public CampaignAnalyticsDto getCampaignAnalytics() {
+        return campaignAnalyticsService.getCampaignAnalytics();
+    }
+}

--- a/xtremand-analytics/src/main/java/com/xtremand/analytics/service/CampaignAnalyticsService.java
+++ b/xtremand-analytics/src/main/java/com/xtremand/analytics/service/CampaignAnalyticsService.java
@@ -1,0 +1,199 @@
+package com.xtremand.analytics.service;
+
+import com.xtremand.domain.dto.CampaignAnalyticsDto;
+import com.xtremand.email.repository.CampaignRepository;
+import com.xtremand.email.repository.EmailAnalyticsRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CampaignAnalyticsService {
+
+    private final EmailAnalyticsRepository emailAnalyticsRepository;
+    private final CampaignRepository campaignRepository;
+
+    public CampaignAnalyticsService(EmailAnalyticsRepository emailAnalyticsRepository, CampaignRepository campaignRepository) {
+        this.emailAnalyticsRepository = emailAnalyticsRepository;
+        this.campaignRepository = campaignRepository;
+    }
+
+    public CampaignAnalyticsDto getCampaignAnalytics() {
+        CampaignAnalyticsDto campaignAnalyticsDto = new CampaignAnalyticsDto();
+        CampaignAnalyticsDto.EmailCampaignMetrics emailCampaignMetrics = new CampaignAnalyticsDto.EmailCampaignMetrics();
+
+        emailCampaignMetrics.setOverview(getOverview());
+        emailCampaignMetrics.setMonthlyPerformance(getMonthlyPerformance());
+        emailCampaignMetrics.setCampaignComparison(getCampaignComparison());
+        emailCampaignMetrics.setDeliveryStatus(getDeliveryStatus());
+        emailCampaignMetrics.setHourlyData(getHourlyData());
+        emailCampaignMetrics.setDevicePerformance(getDevicePerformance());
+        emailCampaignMetrics.setCountryPerformance(getCountryPerformance());
+        emailCampaignMetrics.setFilters(getFilters());
+        emailCampaignMetrics.setMetadata(getMetadata());
+
+        campaignAnalyticsDto.setEmailCampaignMetrics(emailCampaignMetrics);
+        return campaignAnalyticsDto;
+    }
+
+    private CampaignAnalyticsDto.Filters getFilters() {
+        CampaignAnalyticsDto.Filters filters = new CampaignAnalyticsDto.Filters();
+        filters.setTimeRanges(java.util.Arrays.asList("Last Week", "Last Month", "Last 6 Months", "Last Year", "Last 2 Years"));
+        filters.setCampaigns(java.util.Arrays.asList("All Campaigns", "Welcome Series", "Product Demo", "Newsletter", "Re-engagement", "Follow-up", "Promotional"));
+        filters.setCountries(java.util.Arrays.asList("All Countries", "US", "UK", "CA", "AU", "DE", "FR", "IN", "BR", "JP", "SG"));
+        filters.setDevices(java.util.Arrays.asList("All Devices", "Desktop", "Mobile"));
+        filters.setTimeOfDay(java.util.Arrays.asList("All Day", "AM", "PM"));
+        return filters;
+    }
+
+    private CampaignAnalyticsDto.Metadata getMetadata() {
+        CampaignAnalyticsDto.Metadata metadata = new CampaignAnalyticsDto.Metadata();
+        metadata.setTotalRecords(emailAnalyticsRepository.count());
+        metadata.setLastUpdated(java.time.LocalDateTime.now().toString());
+        return metadata;
+    }
+
+    private CampaignAnalyticsDto.DevicePerformance getDevicePerformance() {
+        CampaignAnalyticsDto.DevicePerformance devicePerformance = new CampaignAnalyticsDto.DevicePerformance();
+        CampaignAnalyticsDto.PerformanceMetrics mobile = emailAnalyticsRepository.findDevicePerformance("mobile");
+        CampaignAnalyticsDto.PerformanceMetrics desktop = emailAnalyticsRepository.findDevicePerformance("desktop");
+        long totalSent = mobile.getSent() + desktop.getSent();
+
+        mobile.setOpenRate(calculateRate(mobile.getOpened(), mobile.getDelivered()));
+        mobile.setClickRate(calculateRate(mobile.getClicked(), mobile.getDelivered()));
+        mobile.setReplyRate(calculateRate(mobile.getReplied(), mobile.getDelivered()));
+        mobile.setPercentage(calculateRate(mobile.getSent(), totalSent));
+
+        desktop.setOpenRate(calculateRate(desktop.getOpened(), desktop.getDelivered()));
+        desktop.setClickRate(calculateRate(desktop.getClicked(), desktop.getDelivered()));
+        desktop.setReplyRate(calculateRate(desktop.getReplied(), desktop.getDelivered()));
+        desktop.setPercentage(calculateRate(desktop.getSent(), totalSent));
+
+        devicePerformance.setMobile(mobile);
+        devicePerformance.setDesktop(desktop);
+        return devicePerformance;
+    }
+
+    private java.util.List<CampaignAnalyticsDto.CountryPerformance> getCountryPerformance() {
+        java.util.List<CampaignAnalyticsDto.CountryPerformance> countryPerformanceList = emailAnalyticsRepository.findCountryPerformance();
+        for (CampaignAnalyticsDto.CountryPerformance cp : countryPerformanceList) {
+            cp.setOpenRate(calculateRate(cp.getOpened(), cp.getDelivered()));
+            cp.setClickRate(calculateRate(cp.getClicked(), cp.getDelivered()));
+            cp.setReplyRate(calculateRate(cp.getReplied(), cp.getDelivered()));
+        }
+        return countryPerformanceList;
+    }
+
+    private java.util.List<CampaignAnalyticsDto.HourlyData> getHourlyData() {
+        java.util.List<CampaignAnalyticsDto.HourlyData> hourlyDataList = emailAnalyticsRepository.findHourlyPerformance();
+        for (CampaignAnalyticsDto.HourlyData hd : hourlyDataList) {
+            hd.setHour(getHourName(hd.getHourIndex()));
+        }
+        return hourlyDataList;
+    }
+
+    private String getHourName(int hourIndex) {
+        if (hourIndex == 0) {
+            return "12AM";
+        } else if (hourIndex < 12) {
+            return hourIndex + "AM";
+        } else if (hourIndex == 12) {
+            return "12PM";
+        } else {
+            return (hourIndex - 12) + "PM";
+        }
+    }
+
+    private java.util.List<CampaignAnalyticsDto.DeliveryStatus> getDeliveryStatus() {
+        java.util.List<CampaignAnalyticsDto.DeliveryStatus> deliveryStatusList = new java.util.ArrayList<>();
+        long totalSent = emailAnalyticsRepository.countBySentAtIsNotNull();
+        long totalBounced = emailAnalyticsRepository.countByBouncedAtIsNotNull();
+        long totalDelivered = totalSent - totalBounced;
+
+        CampaignAnalyticsDto.DeliveryStatus delivered = new CampaignAnalyticsDto.DeliveryStatus();
+        delivered.setType("Delivered");
+        delivered.setValue(calculateRate(totalDelivered, totalSent));
+        delivered.setColor("#0ea5e9");
+        deliveryStatusList.add(delivered);
+
+        CampaignAnalyticsDto.DeliveryStatus bounced = new CampaignAnalyticsDto.DeliveryStatus();
+        bounced.setType("Bounced");
+        bounced.setValue(calculateRate(totalBounced, totalSent));
+        bounced.setColor("#ef4444");
+        deliveryStatusList.add(bounced);
+
+        return deliveryStatusList;
+    }
+
+    private java.util.List<CampaignAnalyticsDto.CampaignComparison> getCampaignComparison() {
+        java.util.List<com.xtremand.domain.entity.Campaign> campaigns = campaignRepository.findAll();
+        java.util.List<CampaignAnalyticsDto.CampaignComparison> campaignComparisons = new java.util.ArrayList<>();
+        for (com.xtremand.domain.entity.Campaign campaign : campaigns) {
+            CampaignAnalyticsDto.CampaignComparison cc = new CampaignAnalyticsDto.CampaignComparison();
+            cc.setName(campaign.getName());
+            long sent = emailAnalyticsRepository.countByCampaignIdAndSentAtIsNotNull(campaign.getId());
+            long bounced = emailAnalyticsRepository.countByCampaignIdAndBouncedAtIsNotNull(campaign.getId());
+            long delivered = sent - bounced;
+            long opened = emailAnalyticsRepository.countByCampaignIdAndOpenedAtIsNotNull(campaign.getId());
+            long clicked = emailAnalyticsRepository.countByCampaignIdAndClickedAtIsNotNull(campaign.getId());
+            long replied = emailAnalyticsRepository.countByCampaignIdAndRepliedAtIsNotNull(campaign.getId());
+
+            cc.setSent(sent);
+            cc.setOpened(opened);
+            cc.setClicked(clicked);
+            cc.setReplied(replied);
+
+            cc.setOpenRate(calculateRate(opened, delivered));
+            cc.setClickRate(calculateRate(clicked, delivered));
+            cc.setReplyRate(calculateRate(replied, delivered));
+            campaignComparisons.add(cc);
+        }
+        return campaignComparisons;
+    }
+
+    private java.util.List<CampaignAnalyticsDto.MonthlyPerformance> getMonthlyPerformance() {
+        java.util.List<CampaignAnalyticsDto.MonthlyPerformance> monthlyPerformanceList = emailAnalyticsRepository.findMonthlyPerformance();
+        for (CampaignAnalyticsDto.MonthlyPerformance mp : monthlyPerformanceList) {
+            mp.setMonth(getMonthName(mp.getMonthIndex()));
+            mp.setOpenRate(calculateRate(mp.getOpened(), mp.getDelivered()));
+            mp.setClickRate(calculateRate(mp.getClicked(), mp.getDelivered()));
+            mp.setReplyRate(calculateRate(mp.getReplied(), mp.getDelivered()));
+        }
+        return monthlyPerformanceList;
+    }
+
+    private String getMonthName(int monthIndex) {
+        java.text.DateFormatSymbols dfs = new java.text.DateFormatSymbols();
+        return dfs.getShortMonths()[monthIndex - 1];
+    }
+
+    private CampaignAnalyticsDto.Overview getOverview() {
+        CampaignAnalyticsDto.Overview overview = new CampaignAnalyticsDto.Overview();
+        long totalSent = emailAnalyticsRepository.countBySentAtIsNotNull();
+        long totalBounced = emailAnalyticsRepository.countByBouncedAtIsNotNull();
+        long totalDelivered = totalSent - totalBounced;
+        long totalOpened = emailAnalyticsRepository.countByOpenedAtIsNotNull();
+        long totalClicked = emailAnalyticsRepository.countByClickedAtIsNotNull();
+        long totalReplied = emailAnalyticsRepository.countByRepliedAtIsNotNull();
+
+        overview.setTotalSent(totalSent);
+        overview.setTotalDelivered(totalDelivered);
+        overview.setTotalOpened(totalOpened);
+        overview.setTotalClicked(totalClicked);
+        overview.setTotalReplied(totalReplied);
+        overview.setTotalBounced(totalBounced);
+
+        overview.setOpenRate(calculateRate(totalOpened, totalDelivered));
+        overview.setClickRate(calculateRate(totalClicked, totalDelivered));
+        overview.setReplyRate(calculateRate(totalReplied, totalDelivered));
+        overview.setDeliveryRate(calculateRate(totalDelivered, totalSent));
+        overview.setBounceRate(calculateRate(totalBounced, totalSent));
+
+        return overview;
+    }
+
+    private double calculateRate(long numerator, long denominator) {
+        if (denominator == 0) {
+            return 0.0;
+        }
+        return ((double) numerator / denominator) * 100;
+    }
+}

--- a/xtremand-auth/src/main/java/com/xtremand/auth/config/SecurityConfig.java
+++ b/xtremand-auth/src/main/java/com/xtremand/auth/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
 		http.csrf(csrf -> csrf.disable())
 				.authorizeHttpRequests(auth -> auth
 						.requestMatchers("/auth/login", "/auth/signup", "/contacts/**", "/ai/**", "/emails/**",
-								"/sms/**", "/whatsapp/**","/campaigns/**", "/swagger-ui/**", "/swagger-ui.html","/**")
+								"/sms/**", "/whatsapp/**","/campaigns/**", "/analytics/campaigns", "/swagger-ui/**", "/swagger-ui.html","/**")
 						.permitAll().anyRequest().authenticated())
 				.addFilterBefore(requestIdFilter, UsernamePasswordAuthenticationFilter.class);
 		return http.build();

--- a/xtremand-communication/xtremand-email/src/main/java/com/xtremand/email/repository/EmailAnalyticsRepository.java
+++ b/xtremand-communication/xtremand-email/src/main/java/com/xtremand/email/repository/EmailAnalyticsRepository.java
@@ -18,11 +18,52 @@ public interface EmailAnalyticsRepository extends JpaRepository<EmailAnalytics, 
     int countByCampaignIdAndRepliedAtIsNotNull(Long campaignId);
     int countByCampaignIdAndBouncedAtIsNotNull(Long campaignId);
     
-    long countBySentAtIsNotNull();  
+    long countBySentAtIsNotNull();
 
-    long countByOpenedAtIsNotNull(); 
+    long countByOpenedAtIsNotNull();
 
     long countByRepliedAtIsNotNull();
 
+    long countByBouncedAtIsNotNull();
 
+    long countByClickedAtIsNotNull();
+
+    @org.springframework.data.jpa.repository.Query("SELECT new com.xtremand.domain.dto.CampaignAnalyticsDto.MonthlyPerformance(MONTH(e.sentAt), " +
+            "SUM(CASE WHEN e.sentAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.sentAt IS NOT NULL AND e.bouncedAt IS NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.openedAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.clickedAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.repliedAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.bouncedAt IS NOT NULL THEN 1 ELSE 0 END)) " +
+            "FROM EmailAnalytics e " +
+            "GROUP BY MONTH(e.sentAt)")
+    java.util.List<com.xtremand.domain.dto.CampaignAnalyticsDto.MonthlyPerformance> findMonthlyPerformance();
+
+    @org.springframework.data.jpa.repository.Query("SELECT new com.xtremand.domain.dto.CampaignAnalyticsDto.HourlyData(HOUR(e.openedAt), " +
+            "SUM(CASE WHEN e.openedAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.clickedAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.repliedAt IS NOT NULL THEN 1 ELSE 0 END)) " +
+            "FROM EmailAnalytics e " +
+            "GROUP BY HOUR(e.openedAt)")
+    java.util.List<com.xtremand.domain.dto.CampaignAnalyticsDto.HourlyData> findHourlyPerformance();
+
+    @org.springframework.data.jpa.repository.Query("SELECT new com.xtremand.domain.dto.CampaignAnalyticsDto.PerformanceMetrics(" +
+            "SUM(CASE WHEN e.sentAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.sentAt IS NOT NULL AND e.bouncedAt IS NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.openedAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.clickedAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.repliedAt IS NOT NULL THEN 1 ELSE 0 END)) " +
+            "FROM EmailAnalytics e " +
+            "WHERE e.device = :device")
+    com.xtremand.domain.dto.CampaignAnalyticsDto.PerformanceMetrics findDevicePerformance(String device);
+
+    @org.springframework.data.jpa.repository.Query("SELECT new com.xtremand.domain.dto.CampaignAnalyticsDto.CountryPerformance(e.country, " +
+            "SUM(CASE WHEN e.sentAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.sentAt IS NOT NULL AND e.bouncedAt IS NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.openedAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.clickedAt IS NOT NULL THEN 1 ELSE 0 END), " +
+            "SUM(CASE WHEN e.repliedAt IS NOT NULL THEN 1 ELSE 0 END)) " +
+            "FROM EmailAnalytics e " +
+            "GROUP BY e.country")
+    java.util.List<com.xtremand.domain.dto.CampaignAnalyticsDto.CountryPerformance> findCountryPerformance();
 }

--- a/xtremand-domain/src/main/java/com/xtremand/domain/dto/CampaignAnalyticsDto.java
+++ b/xtremand-domain/src/main/java/com/xtremand/domain/dto/CampaignAnalyticsDto.java
@@ -1,0 +1,163 @@
+package com.xtremand.domain.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.Data;
+
+@Data
+public class CampaignAnalyticsDto {
+    private EmailCampaignMetrics emailCampaignMetrics;
+
+    @Data
+    public static class EmailCampaignMetrics {
+        private Overview overview;
+        private List<MonthlyPerformance> monthlyPerformance;
+        private List<CampaignComparison> campaignComparison;
+        private List<DeliveryStatus> deliveryStatus;
+        private List<HourlyData> hourlyData;
+        private DevicePerformance devicePerformance;
+        private List<CountryPerformance> countryPerformance;
+        private Filters filters;
+        private Metadata metadata;
+    }
+
+    @Data
+    public static class Overview {
+        private long totalSent;
+        private long totalDelivered;
+        private long totalOpened;
+        private long totalClicked;
+        private long totalReplied;
+        private long totalBounced;
+        private double openRate;
+        private double clickRate;
+        private double replyRate;
+        private double deliveryRate;
+        private double bounceRate;
+    }
+
+    @Data
+    public static class MonthlyPerformance {
+        private String month;
+        private int monthIndex;
+        private long sent;
+        private long delivered;
+        private long opened;
+        private long clicked;
+        private long replied;
+        private long bounced;
+        private double openRate;
+        private double clickRate;
+        private double replyRate;
+
+        public MonthlyPerformance(int monthIndex, long sent, long delivered, long opened, long clicked, long replied, long bounced) {
+            this.monthIndex = monthIndex;
+            this.sent = sent;
+            this.delivered = delivered;
+            this.opened = opened;
+            this.clicked = clicked;
+            this.replied = replied;
+            this.bounced = bounced;
+        }
+    }
+
+    @Data
+    public static class CampaignComparison {
+        private String name;
+        private long sent;
+        private long opened;
+        private long clicked;
+        private long replied;
+        private double openRate;
+        private double clickRate;
+        private double replyRate;
+    }
+
+    @Data
+    public static class DeliveryStatus {
+        private String type;
+        private double value;
+        private String color;
+    }
+
+    @Data
+    public static class HourlyData {
+        private String hour;
+        private int hourIndex;
+        private long opens;
+        private long clicks;
+        private long replies;
+
+        public HourlyData(int hourIndex, long opens, long clicks, long replies) {
+            this.hourIndex = hourIndex;
+            this.opens = opens;
+            this.clicks = clicks;
+            this.replies = replies;
+        }
+    }
+
+    @Data
+    public static class DevicePerformance {
+        private PerformanceMetrics mobile;
+        private PerformanceMetrics desktop;
+    }
+
+    @Data
+    public static class PerformanceMetrics {
+        private long sent;
+        private long delivered;
+        private long opened;
+        private long clicked;
+        private long replied;
+        private double openRate;
+        private double clickRate;
+        private double replyRate;
+        private double percentage;
+
+        public PerformanceMetrics(long sent, long delivered, long opened, long clicked, long replied) {
+            this.sent = sent;
+            this.delivered = delivered;
+            this.opened = opened;
+            this.clicked = clicked;
+            this.replied = replied;
+        }
+    }
+
+    @Data
+    public static class CountryPerformance {
+        private String country;
+        private long sent;
+        private long delivered;
+        private long opened;
+        private long clicked;
+        private long replied;
+        private double openRate;
+        private double clickRate;
+        private double replyRate;
+
+        public CountryPerformance(String country, long sent, long delivered, long opened, long clicked, long replied) {
+            this.country = country;
+            this.sent = sent;
+            this.delivered = delivered;
+            this.opened = opened;
+            this.clicked = clicked;
+            this.replied = replied;
+        }
+    }
+
+    @Data
+    public static class Filters {
+        private List<String> timeRanges;
+        private List<String> campaigns;
+        private List<String> countries;
+        private List<String> devices;
+        private List<String> timeOfDay;
+    }
+
+    @Data
+    public static class Metadata {
+        private long totalRecords;
+        private String lastUpdated;
+    }
+}

--- a/xtremand-domain/src/main/java/com/xtremand/domain/entity/EmailAnalytics.java
+++ b/xtremand-domain/src/main/java/com/xtremand/domain/entity/EmailAnalytics.java
@@ -56,4 +56,10 @@ public class EmailAnalytics {
 	@ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "campaign_id", nullable = false)
     private Campaign campaign;
+
+    @Column(name = "device")
+    private String device;
+
+    @Column(name = "country")
+    private String country;
 }


### PR DESCRIPTION
This commit introduces a new API endpoint to retrieve detailed campaign analytics.

The new endpoint `/analytics/campaigns` provides a comprehensive overview of campaign performance, including:
- Overall metrics (sent, delivered, opened, clicked, replied, bounced)
- Monthly performance breakdown
- Campaign comparison
- Delivery status
- Hourly performance data
- Device performance (mobile vs. desktop)
- Country-wise performance

To support this, the following changes were made:
- Added new DTOs in the `xtremand-domain` module to represent the analytics data structure.
- Created a new `xtremand-analytics` module with a dedicated controller and service for the analytics API.
- Extended the `EmailAnalyticsRepository` with new JPQL queries to fetch the required data.
- Added `device` and `country` fields to the `EmailAnalytics` entity.
- Updated the security configuration to allow public access to the new endpoint.